### PR TITLE
Re-read config with repl refresh.

### DIFF
--- a/src/outpace/config.clj
+++ b/src/outpace/config.clj
@@ -141,11 +141,16 @@
       (throw (IllegalArgumentException. (str "Configuration keys must be namespaced symbols: " (pr-str invalid-keys)))))
     (vary-meta config-map assoc ::source source)))
 
+(defn load-config
+  "Finds and loads config."
+  []
+  (if-let [source (find-config-source)]
+    (read-config source)
+    {}))
+
 (def config
   "The delayed map of explicit configuration values."
-  (delay (if-let [source (find-config-source)]
-           (read-config source)
-           {})))
+  (delay (load-config)))
 
 (defn present?
   "Returns true if a configuration entry exists for the qname and, if an

--- a/src/outpace/config/repl.clj
+++ b/src/outpace/config/repl.clj
@@ -1,5 +1,6 @@
 (ns outpace.config.repl
   (:require [clojure.tools.namespace.repl :as nsr]
+            [outpace.config :as config]
             [outpace.config.bootstrap :as boot]))
 
 (defn reload
@@ -7,8 +8,9 @@
    If provided, config-source will be used as the configuration source, and must
    be a value acceptable to clojure.java.io/reader."
   ([]
-    (nsr/disable-reload! (find-ns 'outpace.config.bootstrap))
-    (nsr/refresh-all))
+   (alter-var-root #'config/config (constantly (delay (config/load-config))))
+   (nsr/disable-reload! (find-ns 'outpace.config.bootstrap))
+   (nsr/refresh-all))
   ([config-source]
-    (alter-var-root #'boot/explicit-config-source (constantly config-source))
-    (reload)))
+   (alter-var-root #'boot/explicit-config-source (constantly config-source))
+   (reload)))


### PR DESCRIPTION
`outpace.config.repl/reload` was not actually re-reading any config values. This change resets the delay so reload will re-read config values.