### PR TITLE
Do not read config when compiling.

### DIFF
--- a/test/outpace/config_test.clj
+++ b/test/outpace/config_test.clj
@@ -359,7 +359,11 @@
           (is (nil? (:doc (meta #'hhh))))
           (is (= :config hhh))
           (is (not (contains? @c/non-defaulted `hhh)))
-          (is (= :default3 (@c/defaults `hhh))))))))
+          (is (= :default3 (@c/defaults `hhh)))))))
+  (testing "When compiling should not read config"
+    (binding [*compile-files* true]
+      (with-redefs [c/config (delay (throw (java.io.FileNotFoundException. "should never happen")))]
+        (defconfig iii)))))
 
 (deftest test-defconfig!
   (testing "Preserves metadata"


### PR DESCRIPTION
We ran into an issue where we were compiling some Clojurescript that used a cljc file which had a defconfig (conditionally for clojure), and it failed because it couldn't find the config file.

As far as I know, there's not really any need to read the config file during compilation (the resolution of config values is already delayed to load time, as well).