### PR TITLE
Print a warning when config cannot be found

### DIFF
--- a/src/outpace/config/bootstrap.clj
+++ b/src/outpace/config/bootstrap.clj
@@ -22,4 +22,5 @@
         (io/resource res)
         (or (System/getProperty "config.edn")
             (when (.exists (io/file "config.edn"))
-              "config.edn")))))
+              "config.edn")))
+      (println "WARNING: no config source could be found.")))


### PR DESCRIPTION
This modest patch presents a warning to the user whenever configuration cannot be found in the expected locations. The motivation for this stems from being frustrated by

```
Missing required value for config var: foo.bar/baz
```

and the subsequent giant pile of stack trace when the file is missing. In general, I think I would prefer a much better error message when config value is missing i.e. it couldn't be found because the configuration source was missing vs. it couldn't be found because it wasn't specified in the source. These are distinct situations and warrant distinct messages.

I think this could easily be improved by having `load-config` annotate the return value of `(read-config source)` with meta indicating it's source and subsequently providing a helper function to access that information. These additions would be enough to produce a better error message in `defconfig`.

```clj
(defn load-config
  "Finds and loads config."
  []
  (if-let [source (find-config-source)]
    (with-meta (read-config source) :source source)
    {}))

(defn config-source
  "Returns the source of config as string or nil if no source was
  found."
  []
  (when-let [source (:source (meta @config))]
    (str source)))

;; In defconfig.
(if (present? qname#)
  (alter-var-root var# (constantly (lookup qname#)))
  (when (and (-> var# meta :required) (not generating?))
    ;; This is the the change.
    (let [message# (if-let [source (config-source)]
                     (str "Config var " qname# " must define a default or be specified in " source)
                     (str "Config var " qname# " must define a default when there is no config source"))]
      (throw (Exception. message#)))))
```

I'm happy to revise and submit these proposals as a proper patch provide the reception is positive. The changes are safe, simple and would not result in breakage.